### PR TITLE
fix batching in SignalFx output plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.5.1.sfx1 [2018-01-16]
+
+### Release Notes
+
+- Minor bug fix to correctly batch metrics in SignalFx output plugin
+- Minor enhancement to ensure SignalFx metadata plugin has at least 1 go routine to gather process list information
+
 ## v1.5.1.sfx0 [2018-01-12]
 
 ### Release Notes

--- a/plugins/inputs/signalfx_metadata/process-info.go
+++ b/plugins/inputs/signalfx_metadata/process-info.go
@@ -25,8 +25,11 @@ func NewProcessInfo(bufferSize int, numWorkers int) *ProcessInfo {
 		bufferSize: bufferSize,
 		numWorkers: numWorkers,
 	}
-
-	for i := 0; i < numWorkers; i++ {
+	// ensure that the number of workers is always 1
+	if s.numWorkers < 1 {
+		s.numWorkers = 1
+	}
+	for i := 0; i < s.numWorkers; i++ {
 		newWorkerProcess(s.processIn)
 	}
 

--- a/plugins/inputs/signalfx_metadata/signalfx-metadata.go
+++ b/plugins/inputs/signalfx_metadata/signalfx-metadata.go
@@ -16,6 +16,7 @@ const pluginVersion = "0.0.30"
 var sampleConfig = `
   ## SignalFx metadata plugin reports metadata properties for the host
   ## Process List Collection Settings
+  ## number of go routines used to collect the process list (must be 1 or greater)
   # NumberOfGoRoutines = 3
   ## The buffer size should be greater than or equal to the length of all 
   ## processes on the host

--- a/plugins/outputs/signalfx/signalfx.go
+++ b/plugins/outputs/signalfx/signalfx.go
@@ -361,11 +361,9 @@ func (s *SignalFx) Write(metrics []telegraf.Metric) error {
 				}
 			}
 		}
-		s.emitDatapoints(datapoints)
-		datapoints = datapoints[:0]
-		s.emitEvents(events)
-		events = events[:0]
 	}
+	s.emitDatapoints(datapoints)
+	s.emitEvents(events)
 	return nil
 }
 

--- a/plugins/outputs/signalfx/signalfx.go
+++ b/plugins/outputs/signalfx/signalfx.go
@@ -331,7 +331,7 @@ func (s *SignalFx) Write(metrics []telegraf.Metric) error {
 				// Add metric as a datapoint
 				datapoints = append(datapoints, dp)
 
-				if len(datapoints) == s.BatchSize {
+				if len(datapoints) >= s.BatchSize {
 					s.emitDatapoints(datapoints)
 					datapoints = datapoints[:0]
 				}
@@ -355,7 +355,7 @@ func (s *SignalFx) Write(metrics []telegraf.Metric) error {
 				// Add event
 				events = append(events, ev)
 
-				if len(events) == s.BatchSize {
+				if len(events) >= s.BatchSize {
 					s.emitEvents(events)
 					events = events[:0]
 				}


### PR DESCRIPTION
* ensure when batchsize is 0 that batching doesn't occur in SignalFx output plugin
* ensure process list collection has at least 1 go routine in SignalFx metadata plugin