### PR TITLE
Add cmdline tag to procstat input (#5681) (cherry pick)

### DIFF
--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -41,6 +41,9 @@ Processes can be selected for monitoring using one of several methods:
   ## Field name prefix
   # prefix = ""
 
+  ## When true add the full cmdline as a tag.
+  # cmdline_tag = false
+
   ## Add PID as a tag instead of a field; useful to differentiate between
   ## processes whose tags are otherwise the same.  Can create a large number
   ## of series, use judiciously.
@@ -72,6 +75,7 @@ implemented as a WMI query.  The pattern allows fuzzy matching using only
 - procstat
   - tags:
     - pid (when `pid_tag` is true)
+    - cmdline (when 'cmdline_tag' is true)
     - process_name
     - pidfile (when defined)
     - exe (when defined)

--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -15,6 +15,7 @@ type Process interface {
 	IOCounters() (*process.IOCountersStat, error)
 	MemoryInfo() (*process.MemoryInfoStat, error)
 	Name() (string, error)
+	Cmdline() (string, error)
 	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
 	NumFDs() (int32, error)
 	NumThreads() (int32, error)

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -76,6 +76,10 @@ func (pg *testPgrep) PidFile(path string) ([]PID, error) {
 	return pg.pids, pg.err
 }
 
+func (p *testProc) Cmdline() (string, error) {
+	return "test_proc", nil
+}
+
 func (pg *testPgrep) Pattern(pattern string) ([]PID, error) {
 	return pg.pids, pg.err
 }


### PR DESCRIPTION
backport d2666d0db6927d324422dcc3ec7e9c38e2b3704b from upstream https://github.com/influxdata/telegraf) 
https://github.com/influxdata/telegraf/pull/5681