### PR TITLE
Cherry Pick Upstream PR 6249 - signalfx-agent branch

### DIFF
--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -20,6 +20,7 @@ type Process interface {
 	NumFDs() (int32, error)
 	NumThreads() (int32, error)
 	Percent(interval time.Duration) (float64, error)
+	MemoryPercent() (float32, error)
 	Times() (*cpu.TimesStat, error)
 	RlimitUsage(bool) ([]process.RlimitStat, error)
 	Username() (string, error)

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -237,6 +237,11 @@ func (p *Procstat) addMetric(proc Process, acc telegraf.Accumulator) {
 		fields[prefix+"memory_locked"] = mem.Locked
 	}
 
+	mem_perc, err := proc.MemoryPercent()
+	if err == nil {
+		fields[prefix+"memory_usage"] = mem_perc
+	}
+
 	rlims, err := proc.RlimitUsage(true)
 	if err == nil {
 		for _, rlim := range rlims {

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -144,6 +144,10 @@ func (p *testProc) Percent(interval time.Duration) (float64, error) {
 	return 0, nil
 }
 
+func (p *testProc) MemoryPercent() (float32, error) {
+	return 0, nil
+}
+
 func (p *testProc) Times() (*cpu.TimesStat, error) {
 	return &cpu.TimesStat{}, nil
 }


### PR DESCRIPTION
Cherry picked the following from upstream:
`e36639b15d597b56157c431bfc91464b0e9db52a`

To add the `memory_usage` metric.