### PR TITLE
fix timeout err message

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -221,11 +221,11 @@ func WaitTimeout(c *exec.Cmd, timeout time.Duration) error {
 	})
 
 	err := c.Wait()
-	isTimeout := timer.Stop()
+	if err == nil {
+		return nil
+	}
 
-	if err != nil {
-		return err
-	} else if isTimeout == false {
+	if !timer.Stop() {
 		return TimeoutErr
 	}
 


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

While debugging SWAT-3387 and after fixing https://github.com/signalfx/signalfx-agent/pull/1937 , I have noticed that the error message that bubbles up to the user is still `error="exec: exit status 1 for command` .
This code will address the issue and it was already fixed upstream https://github.com/influxdata/telegraf/pull/6267/files#r315498691


