### PR TITLE
fix exec WaitTimeout

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -221,11 +221,16 @@ func WaitTimeout(c *exec.Cmd, timeout time.Duration) error {
 	})
 
 	err := c.Wait()
+	// shutdown timer
+	timerFired := !timer.Stop()
+
+	// If err is nil, the process exited cleanly without being killed due to timeout
 	if err == nil {
 		return nil
 	}
 
-	if !timer.Stop() {
+	// return a timeout error instead of the process kill error due to timeout
+	if timerFired {
 		return TimeoutErr
 	}
 


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

In previous PR, I have back ported this change https://github.com/influxdata/telegraf/pull/6267/files#r315498691 , but the fix failed to shutdown the timer causing the main func to return while the timer routine was still running; although this has no impact on functionality and emitting datapoints, but when the exec process exits cleanly the timer routine will eventually log messages like this 
```
E! FATAL error killing process: os: process already finished
```

I verified the fix with different use cases and noticed that the latest version of telegraf addressed the same issue https://github.com/influxdata/telegraf/blob/master/internal/exec_unix.go#L40
