### PR TITLE
adopt microsoft/go-mssqldb

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -258,17 +258,6 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7fdc54859cd901c25b9d8db964410a4e0d98fa0dca267fe4cf49c0eede5e06c2"
-  name = "github.com/denisenkom/go-mssqldb"
-  packages = [
-    ".",
-    "internal/cp",
-  ]
-  pruneopts = ""
-  revision = "1eb28afdf9b6e56cf673badd47545f844fe81103"
-
-[[projects]]
   digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
@@ -1516,7 +1505,6 @@
     "github.com/aws/aws-sdk-go/service/kinesis",
     "github.com/bsm/sarama-cluster",
     "github.com/couchbase/go-couchbase",
-    "github.com/denisenkom/go-mssqldb",
     "github.com/dgrijalva/jwt-go",
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/api/types/container",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -179,8 +179,8 @@
   branch = "master"
 
 [[constraint]]
-  name = "github.com/denisenkom/go-mssqldb"
-  branch = "master"
+  name = "github.com/microsoft/go-mssqldb"
+  branch = "main"
 
 [[constraint]]
   name = "golang.org/x/net"

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -20,7 +20,7 @@ following works:
 - github.com/couchbase/gomemcached [MIT License](https://github.com/couchbase/gomemcached/blob/master/LICENSE)
 - github.com/couchbase/goutils [COUCHBASE INC. COMMUNITY EDITION LICENSE](https://github.com/couchbase/goutils/blob/master/LICENSE.md)
 - github.com/davecgh/go-spew [ISC License](https://github.com/davecgh/go-spew/blob/master/LICENSE)
-- github.com/denisenkom/go-mssqldb [BSD 3-Clause "New" or "Revised" License](https://github.com/denisenkom/go-mssqldb/blob/master/LICENSE.txt)
+- github.com/microsoft/go-mssqldb [BSD 3-Clause "New" or "Revised" License](https://github.com/microsoft/go-mssqldb/blob/main/LICENSE.txt)
 - github.com/dgrijalva/jwt-go [MIT License](https://github.com/dgrijalva/jwt-go/blob/master/LICENSE)
 - github.com/dimchansky/utfbom [Apache License 2.0](https://github.com/dimchansky/utfbom/blob/master/LICENSE)
 - github.com/docker/distribution [Apache License 2.0](https://github.com/docker/distribution/blob/master/LICENSE)

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -3693,7 +3693,7 @@
 #   ## All connection parameters are optional.
 #   ## By default, the host is localhost, listening on default port, TCP 1433.
 #   ##   for Windows, the user is the currently running AD user (SSO).
-#   ##   See https://github.com/denisenkom/go-mssqldb for detailed connection
+#   ##   See https://github.com/microsoft/go-mssqldb for detailed connection
 #   ##   parameters.
 #   # servers = [
 #   #  "Server=192.168.1.10;Port=1433;User Id=<user>;Password=<pw>;app name=telegraf;log=1;",

--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -27,7 +27,7 @@ GO
   ## All connection parameters are optional.
   ## By default, the host is localhost, listening on default port, TCP 1433.
   ##   for Windows, the user is the currently running AD user (SSO).
-  ##   See https://github.com/denisenkom/go-mssqldb for detailed connection
+  ##   See https://github.com/microsoft/go-mssqldb for detailed connection
   ##   parameters.
   # servers = [
   #  "Server=192.168.1.10;Port=1433;User Id=<user>;Password=<pw>;app name=telegraf;log=1;",

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/denisenkom/go-mssqldb" // go-mssqldb initialization
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	_ "github.com/microsoft/go-mssqldb" // go-mssqldb initialization
 )
 
 // SQLServer struct
@@ -40,7 +40,7 @@ var sampleConfig = `
   ## All connection parameters are optional.
   ## By default, the host is localhost, listening on default port, TCP 1433.
   ##   for Windows, the user is the currently running AD user (SSO).
-  ##   See https://github.com/denisenkom/go-mssqldb for detailed connection
+  ##   See https://github.com/microsoft/go-mssqldb for detailed connection
   ##   parameters.
   # servers = [
   #  "Server=192.168.1.10;Port=1433;User Id=<user>;Password=<pw>;app name=telegraf;log=1;",


### PR DESCRIPTION
Need to update go-mssqldb to MS's fork to avoid duplicate driver registration panic (re: https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/0c27a3bccfd1b1f7418cc1ac05a535ce29a5a736).

I couldn't ressurrect my dep/GOPATH env so simply removed the existing gopkg* entries (unused tmk).